### PR TITLE
[dSYMs] Provide a default value for Fastlane action output

### DIFF
--- a/lib/fastlane/plugin/waldo/actions/waldo_action.rb
+++ b/lib/fastlane/plugin/waldo/actions/waldo_action.rb
@@ -23,8 +23,7 @@ module Fastlane
           apk_path_default = Dir["*.apk"].last || Dir[File.join('app', 'build', 'outputs', 'apk', 'app-release.apk')].last
         when :ios
           app_path_default = Dir["*.app"].sort_by { |x| File.mtime(x) }.last
-          # No default dsym_path for now; user must specify it explicitly:
-          # dsym_path_default = (Dir["./**/*.dSYM"] + Dir["./**/*.dSYM.zip"]).sort_by { |x| File.mtime(x) }.last
+          dsym_path_default = Helper::WaldoHelper.get_default_dsym_path
           ipa_path_default = Dir["*.ipa"].sort_by { |x| File.mtime(x) }.last
         end
 
@@ -44,11 +43,9 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :dsym_path,
                                        env_name: 'WALDO_DSYM_PATH',
-                                       # No default dsym_path for now; user must specify it explicitly:
-                                       description: 'Path to your dSYM file(s)',
-                                       # description: 'Path to your dSYM file(s) (optional if you use the _gym_ or _xcodebuild_ action)',
-                                       # default_value: Actions.lane_context[Actions::SharedValues::DSYM_OUTPUT_PATH] || dsym_path_default,
-                                       # default_value_dynamic: true,
+                                       description: 'Path to your dSYM file(s) (optional if you use the _gym_ or _xcodebuild_ action)',
+                                       default_value: dsym_path_default,
+                                       default_value_dynamic: true,
                                        optional: true),
           # Android-specific
           FastlaneCore::ConfigItem.new(key: :apk_path,

--- a/lib/fastlane/plugin/waldo/helper/waldo_helper.rb
+++ b/lib/fastlane/plugin/waldo/helper/waldo_helper.rb
@@ -130,6 +130,12 @@ module Fastlane
         Base64.strict_encode64("[#{history.join(',')}]")
       end
 
+      def self.get_default_dsym_path
+        path = (Dir["./**/*.dSYM"] + Dir["./**/*.dSYM.zip"]).sort_by { |x| File.mtime(x) }.last
+        dsyms_output_path = Actions.lane_context[Actions::SharedValues::DSYM_OUTPUT_PATH] if defined? Actions::SharedValues::DSYM_OUTPUT_PATH
+        dsyms_output_path || path
+      end
+
       def self.get_platform
         Actions.lane_context[Actions::SharedValues::PLATFORM_NAME] || :ios
       end


### PR DESCRIPTION
I realize you likely didn't implement this for a reason, but wanted to make sure it worked for us out-of-the-box rather than specifying a path in CI.

E.g.
```
INFO [2020-04-15 21:25:48.90]: Build successfully uploaded to Waldo!
INFO [2020-04-15 21:25:48.90]: Uploading symbols to Waldo
Request: POST /versions/<redacted>/symbols (0 bytes)
  Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
  Accept: */*
  User-Agent: Waldo fastlane/iOS v1.5.0
  Authorization: Upload-Token <redacted>
  Transfer-Encoding: chunked
  Content-Type: application/zip
-------
Response: 200 OK (16 bytes)
  Date: Wed, 15 Apr 2020 21:25:53 GMT
  Content-Type: application/json; charset=utf-8
  Content-Length: 16
  Connection: keep-alive
  Cache-Control: private, no-cache, no-store, must-revalidate
  X-Version: git-3381efd
  Access-Control-Allow-Origin: *
  X-Duration: 3964
{"success":true}
INFO [2020-04-15 21:25:53.08]: Symbols successfully uploaded to Waldo!
```